### PR TITLE
feat グラフのライブラリを置き換え

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,14 +1,14 @@
 🏝islands:
-  - frontend/islands
-🍚types:
-  - frontend/types
+  - frontend/islands/*
+🧩types:
+  - frontend/types/*
 💿libs:
-  - frontend/libs
-🧩components:
-  - frontend/components
-  - frontend/layouts
-👗satic:
-  - frontend/static
+  - frontend/libs/*
+🗃components:
+  - frontend/components/*
+  - frontend/layouts/*
+👗static:
+  - frontend/static/*
 🏠localInfra:
   - docker-compose.yml
   - infra/dev/*

--- a/frontend/components/Graph/ListChart.tsx
+++ b/frontend/components/Graph/ListChart.tsx
@@ -1,6 +1,6 @@
 import { Chart } from "$fresh_charts/mod.ts";
 import { transparentize } from "$fresh_charts/utils.ts";
-import { LineGraphT } from "@🍚/graphT.ts";
+import { LineGraphT } from "@🧩/graphT.ts";
 
 export default function ListChart({ graphData }: LineGraphT) {
   const dataset = graphData.dataList.map((data, index) => ({

--- a/frontend/fresh.gen.ts
+++ b/frontend/fresh.gen.ts
@@ -6,6 +6,7 @@ import config from "./deno.json" assert { type: "json" };
 import * as $0 from "./routes/_404.tsx";
 import * as $1 from "./routes/_500.tsx";
 import * as $2 from "./routes/index.tsx";
+import * as $$0 from "./islands/D3nodataLineChart.tsx";
 
 const manifest = {
   routes: {
@@ -13,7 +14,9 @@ const manifest = {
     "./routes/_500.tsx": $1,
     "./routes/index.tsx": $2,
   },
-  islands: {},
+  islands: {
+    "./islands/D3nodataLineChart.tsx": $$0,
+  },
   baseUrl: import.meta.url,
   config,
 };

--- a/frontend/import_map.json
+++ b/frontend/import_map.json
@@ -2,6 +2,7 @@
   "imports": {
     "$fresh/": "https://deno.land/x/fresh@1.1.1/",
     "$fresh_charts/": "https://deno.land/x/fresh_charts@0.1.0/",
+    "$d3nodata": "https://deno.land/x/d3nodata@v0.1.3.1/charts.ts",
     "$std/": "https://deno.land/std@0.161.0/",
     "preact": "https://esm.sh/preact@10.11.0",
     "preact/": "https://esm.sh/preact@10.11.0/",
@@ -10,9 +11,9 @@
     "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.0.1",
     "twind": "https://esm.sh/twind@0.16.17",
     "twind/": "https://esm.sh/twind@0.16.17/",
-    "@🧩/": "./components/",
+    "@🗃/": "./components/",
     "@🌟/": "./layout/",
-    "@🍚/": "./types/",
+    "@🧩/": "./types/",
     "@💿/": "./libs/",
     "@🏝/": "./islands/"
   }

--- a/frontend/islands/D3nodataLineChart.tsx
+++ b/frontend/islands/D3nodataLineChart.tsx
@@ -1,0 +1,7 @@
+import { LineChart } from "$d3nodata";
+// islandsではエイリアスが効かないので相対パスを入れている↓
+import { BarChartT } from "../types/d3nodata.ts";
+export default function D3nodataLineChart(chartData: BarChartT[]) {
+  console.log(chartData.chartData);
+  return <LineChart datasets={chartData.chartData} />;
+}

--- a/frontend/layout/BasicLayout.tsx
+++ b/frontend/layout/BasicLayout.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from "preact";
 import { Head } from "$fresh/src/runtime/head.ts";
-import Footer from "@🧩/Basis/Footer.tsx";
-import Header from "@🧩/Basis/Header.tsx";
+import Footer from "@🗃/Basis/Footer.tsx";
+import Header from "@🗃/Basis/Header.tsx";
 import { asset } from "$fresh/runtime.ts";
 interface LayoutProps {
   title: string;

--- a/frontend/layout/ErrorLayout.tsx
+++ b/frontend/layout/ErrorLayout.tsx
@@ -1,5 +1,5 @@
 import Layout from "@🌟/BasicLayout.tsx";
-import ErrorCard from "@🧩/Card/ErrorCard.tsx";
+import ErrorCard from "@🗃/Card/ErrorCard.tsx";
 interface ErrorMessages {
   statusCode: number;
   title: string;

--- a/frontend/libs/OperationCoreTransition/CreateMonthlyGraphData.ts
+++ b/frontend/libs/OperationCoreTransition/CreateMonthlyGraphData.ts
@@ -1,5 +1,5 @@
-import { OperationCoreE } from "@🍚/kadodeApiT.ts";
-import { LineGraphT } from "@🍚/graphT.ts";
+import { OperationCoreE } from "@🧩/kadodeApiT.ts";
+import { LineGraphT } from "@🧩/graphT.ts";
 
 const MONTH_ENDPOINT = Deno.env.get("API_URL") +
   "/OperationCoreTransitionPerHours/relative/month";

--- a/frontend/libs/OperationCoreTransition/CreateOperationCoreChartDataToD3nodata.ts
+++ b/frontend/libs/OperationCoreTransition/CreateOperationCoreChartDataToD3nodata.ts
@@ -1,0 +1,52 @@
+import { OperationCoreE } from "@🧩/kadodeApiT.ts";
+import { BarChartT,d3nodataDataT } from "@🧩/d3nodata.ts";
+
+const MONTH_ENDPOINT = Deno.env.get("API_URL") +
+  "/OperationCoreTransitionPerHours/relative/month";
+
+export async function CreateOperationCoreChartDataToD3nodata(): Promise<
+  BarChartT[]
+> {
+  const resp = await fetch(MONTH_ENDPOINT, {
+    method: "GET",
+  });
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`${resp.status} ${body}`);
+  }
+  const jsonData: OperationCoreE[] = await resp.json();
+  if (jsonData.errors) {
+    throw new Error(jsonData.errors.map((e: Error) => e.message).join("\n"));
+  }
+
+  //24個に1個に絞って反転させることでいい感じにグラフで表示できるようにする
+  const monthlyData: OperationCoreE[] = jsonData.filter((e, i) => {
+    return (i % 24 === 0);
+  }).reverse();
+
+  /* @todo 2回日付を作ってて無駄が多いので省きたい */
+  const diaryList: d3nodataDataT[] = monthlyData.map((e) => {
+    const date = new Date(e.created_at);
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    return {x:e.diary_total,y:`${month}/${day}`};
+  });
+  const statisticList: d3nodataDataT[] = monthlyData.map((e) => {
+    const date = new Date(e.created_at);
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    return {x:e.statistic_per_date_total,y:`${month}/${day}`};
+  });
+  return [
+    {
+      label: "statistic",
+      color: "rgb(255, 206, 86)",
+      data: statisticList,
+    },
+    {
+      label: "diary",
+      color: "rgb(54, 162, 235)",
+      data: diaryList,
+    },
+  ];
+}

--- a/frontend/libs/OperationCoreTransition/GetDailyChange.ts
+++ b/frontend/libs/OperationCoreTransition/GetDailyChange.ts
@@ -1,4 +1,4 @@
-import { KadodeDiaryDailyChange, OperationCoreE } from "@🍚/kadodeApiT.ts";
+import { KadodeDiaryDailyChange, OperationCoreE } from "@🧩/kadodeApiT.ts";
 const DAY_ENDPOINT = Deno.env.get("API_URL") +
   "/OperationCoreTransitionPerHours/relative/day";
 

--- a/frontend/routes/index.tsx
+++ b/frontend/routes/index.tsx
@@ -1,30 +1,32 @@
 // コア
-import KadodeLogoAnimation from "@🧩/Animation/KadodeLogoAnimation.tsx";
+import KadodeLogoAnimation from "@🗃/Animation/KadodeLogoAnimation.tsx";
 import { Handlers, PageProps } from "$fresh/server.ts";
 // メソッド
 import {
   getDailyChange,
   getDailyT,
 } from "@💿/OperationCoreTransition/GetDailyChange.ts";
-import { CreateMonthlyGraphData } from "@💿/OperationCoreTransition/CreateMonthlyGraphData.ts";
-import { LineGraphT } from "@🍚/graphT.ts";
+import { CreateOperationCoreChartDataToD3nodata } from "@💿/OperationCoreTransition/CreateOperationCoreChartDataToD3nodata.ts";
+//型
+import { BarChartT } from "@🧩/d3nodata.ts";
 // みため
 import Layout from "@🌟/BasicLayout.tsx";
-import UserChangeCard from "@🧩/Card/UserChangeCard.tsx";
-import ListChart from "@🧩/Graph/ListChart.tsx";
+import UserChangeCard from "@🗃/Card/UserChangeCard.tsx";
+import D3nodataLineChart from "@🏝/D3nodataLineChart.tsx";
 
 type forIndexData = {
   daily: getDailyT;
-  monthlyChart: LineGraphT;
+  monthlyChart: BarChartT[];
 };
 
 export const handler: Handlers<forIndexData> = {
   async GET(_req, ctx) {
     const dailyData = await getDailyChange<getDailyT>();
-    const monthlyData = await CreateMonthlyGraphData<LineGraphT>();
+    const diaryStatisticMonthlyData =
+      await CreateOperationCoreChartDataToD3nodata<BarChartT[]>();
     return ctx.render({
       daily: dailyData,
-      monthlyChart: monthlyData,
+      diaryStatisticMonthlyData: diaryStatisticMonthlyData,
     });
   },
 };
@@ -66,7 +68,7 @@ export default function Home({ data }: PageProps<forIndexData>) {
         </div>
         <div class="graphSection">
           <h2 class="m-4 text-3xl text-center">利用状況の推移</h2>
-          <ListChart graphData={data.monthlyChart} />
+          <D3nodataLineChart chartData={data.diaryStatisticMonthlyData} />
         </div>
       </div>
     </Layout>

--- a/frontend/types/d3nodata.ts
+++ b/frontend/types/d3nodata.ts
@@ -1,0 +1,10 @@
+export interface BarChartT {
+  label: string;
+  color: string;
+  data: d3nodataDataT[];
+}
+
+export interface d3nodataDataT {
+  x: string;
+  y: number;
+}


### PR DESCRIPTION
トップページで表示するライブラリを変更

もともと
https://fresh-charts.deno.dev/

新しいやつ
https://d3nodata.deno.dev/

# 変更による変化

## メリット
- アニメーション描画ができるようになった

## デメリット
- ライブラリが謎な挙動をする
- 内部の型を見るとxにstring,yにnumberを入れるとあるがそうでなくても動く
- ドキュメントとライブラリ内の型定義が違う
- 10/11のように日付を入れると勝手にキャストされて Oct 11とかになる←？？？

0.1系もあって謎な挙動も多い。
ただFreshのライブラリは基本0.1系しか存在しないので、どれとってもリスクある。
ということで、動きが楽しい方に変えた

m5paper用にはfresh_chartを使いたいのでファイルは残している