### PR TITLE
fix 日付が壊れる問題の修正

### DIFF
--- a/frontend/islands/D3nodataLineChart.tsx
+++ b/frontend/islands/D3nodataLineChart.tsx
@@ -1,7 +1,14 @@
 import { LineChart } from "$d3nodata";
 // islandsではエイリアスが効かないので相対パスを入れている↓
 import { BarChartT } from "../types/d3nodata.ts";
+
+/**
+ * 注意
+ * - xとyの値が逆でも入る
+ * - xはDate型またはそれに準じる形でないと壊れる(日本語とか入ると範囲外に点が飛ばされる)
+ * - xはy/m/d入れると自動で 週+日　または 月+日　になる(勝手に調整されるのでこちらで制御出来ないが、月が変わるデータがあると自動で後者になる)
+ * - yの値は整数値だが、微妙に値がずれた結果が出力される
+ */
 export default function D3nodataLineChart(chartData: BarChartT[]) {
-  console.log(chartData.chartData);
   return <LineChart datasets={chartData.chartData} />;
 }

--- a/frontend/libs/OperationCoreTransition/CreateOperationCoreChartDataToD3nodata.ts
+++ b/frontend/libs/OperationCoreTransition/CreateOperationCoreChartDataToD3nodata.ts
@@ -1,11 +1,11 @@
 import { OperationCoreE } from "@🧩/kadodeApiT.ts";
-import { BarChartT,d3nodataDataT } from "@🧩/d3nodata.ts";
+import { LineChartT,d3nodataDataT } from "@🧩/d3nodata.ts";
 
 const MONTH_ENDPOINT = Deno.env.get("API_URL") +
   "/OperationCoreTransitionPerHours/relative/month";
 
 export async function CreateOperationCoreChartDataToD3nodata(): Promise<
-  BarChartT[]
+  LineChartT[]
 > {
   const resp = await fetch(MONTH_ENDPOINT, {
     method: "GET",
@@ -27,15 +27,17 @@ export async function CreateOperationCoreChartDataToD3nodata(): Promise<
   /* @todo 2回日付を作ってて無駄が多いので省きたい */
   const diaryList: d3nodataDataT[] = monthlyData.map((e) => {
     const date = new Date(e.created_at);
+    const year = date.getFullYear();
     const month = date.getMonth() + 1;
     const day = date.getDate();
-    return {x:e.diary_total,y:`${month}/${day}`};
+    return {y:e.diary_total,x:`${year}/${month}/${day}`};
   });
   const statisticList: d3nodataDataT[] = monthlyData.map((e) => {
     const date = new Date(e.created_at);
+    const year = date.getFullYear();
     const month = date.getMonth() + 1;
     const day = date.getDate();
-    return {x:e.statistic_per_date_total,y:`${month}/${day}`};
+    return {y:e.statistic_per_date_total,x:`${year}/${month}/${day}`};
   });
   return [
     {

--- a/frontend/routes/index.tsx
+++ b/frontend/routes/index.tsx
@@ -8,7 +8,7 @@ import {
 } from "@💿/OperationCoreTransition/GetDailyChange.ts";
 import { CreateOperationCoreChartDataToD3nodata } from "@💿/OperationCoreTransition/CreateOperationCoreChartDataToD3nodata.ts";
 //型
-import { BarChartT } from "@🧩/d3nodata.ts";
+import { LineChartT } from "@🧩/d3nodata.ts";
 // みため
 import Layout from "@🌟/BasicLayout.tsx";
 import UserChangeCard from "@🗃/Card/UserChangeCard.tsx";
@@ -16,14 +16,14 @@ import D3nodataLineChart from "@🏝/D3nodataLineChart.tsx";
 
 type forIndexData = {
   daily: getDailyT;
-  monthlyChart: BarChartT[];
+  monthlyChart: LineChartT[];
 };
 
 export const handler: Handlers<forIndexData> = {
   async GET(_req, ctx) {
     const dailyData = await getDailyChange<getDailyT>();
     const diaryStatisticMonthlyData =
-      await CreateOperationCoreChartDataToD3nodata<BarChartT[]>();
+      await CreateOperationCoreChartDataToD3nodata<LineChartT[]>();
     return ctx.render({
       daily: dailyData,
       diaryStatisticMonthlyData: diaryStatisticMonthlyData,

--- a/frontend/types/d3nodata.ts
+++ b/frontend/types/d3nodata.ts
@@ -1,4 +1,4 @@
-export interface BarChartT {
+export interface LineChartT {
   label: string;
   color: string;
   data: d3nodataDataT[];


### PR DESCRIPTION
# 🌟 概要
y/m/dで日付入れないと壊れる

(LineChartのx値がDate型しか受け付けない謎仕様への対処)


勝手に曜日＋日付にされるが、データが増えて月変わると月+日付によしなにしてくれるっぽい