### PR TITLE
feat お知らせとリリースノートをトップページに表示するようにした

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@
   - frontend/libs/*
 🗃components:
   - frontend/components/*
-  - frontend/layouts/*
+  - frontend/layout/*
 👗static:
   - frontend/static/*
 🏠localInfra:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
-  "cSpell.words": ["kadode"],
+  "cSpell.words": [
+    "kadode",
+    "Osirase",
+    "Osirases"
+  ],
   "editor.defaultFormatter": "denoland.vscode-deno"
 }

--- a/frontend/components/Text/IndexHeadline.tsx
+++ b/frontend/components/Text/IndexHeadline.tsx
@@ -1,0 +1,9 @@
+export default function IndexHeadline({ title }: string) {
+  return (
+    <div class="flex justify-center">
+      <h2 class="mx-4 text-3xl text-center mt-20 border-b-2 bg-kn_white border-dotted pb-2 px-2 rounded-xl border-kn_black">
+        {title}
+      </h2>
+    </div>
+  );
+}

--- a/frontend/libs/OperationCoreTransition/CreateMonthlyGraphData.ts
+++ b/frontend/libs/OperationCoreTransition/CreateMonthlyGraphData.ts
@@ -1,11 +1,11 @@
 import { OperationCoreE } from "@🧩/kadodeApiT.ts";
 import { LineGraphT } from "@🧩/graphT.ts";
 
-const MONTH_ENDPOINT = Deno.env.get("API_URL") +
+const ENDPOINT = Deno.env.get("API_URL") +
   "/OperationCoreTransitionPerHours/relative/month";
 
 export async function CreateMonthlyGraphData(): Promise<LineGraphT> {
-  const resp = await fetch(MONTH_ENDPOINT, {
+  const resp = await fetch(ENDPOINT, {
     method: "GET",
   });
   if (!resp.ok) {

--- a/frontend/libs/OperationCoreTransition/CreateOperationCoreChartDataToD3nodata.ts
+++ b/frontend/libs/OperationCoreTransition/CreateOperationCoreChartDataToD3nodata.ts
@@ -1,13 +1,13 @@
 import { OperationCoreE } from "@🧩/kadodeApiT.ts";
 import { lineChartT,d3nodataDataT } from "@🧩/d3nodata.ts";
 
-const MONTH_ENDPOINT = Deno.env.get("API_URL") +
+const ENDPOINT = Deno.env.get("API_URL") +
   "/OperationCoreTransitionPerHours/relative/month";
 
 export async function CreateOperationCoreChartDataToD3nodata(): Promise<
   lineChartT[]
 > {
-  const resp = await fetch(MONTH_ENDPOINT, {
+  const resp = await fetch(ENDPOINT, {
     method: "GET",
   });
   if (!resp.ok) {

--- a/frontend/libs/OperationCoreTransition/GetDailyChange.ts
+++ b/frontend/libs/OperationCoreTransition/GetDailyChange.ts
@@ -1,5 +1,5 @@
 import { KadodeDiaryDailyChange, OperationCoreE } from "@🧩/kadodeApiT.ts";
-const DAY_ENDPOINT = Deno.env.get("API_URL") +
+const ENDPOINT = Deno.env.get("API_URL") +
   "/OperationCoreTransitionPerHours/relative/day";
 
 export type getDailyT = {
@@ -8,7 +8,7 @@ export type getDailyT = {
   last1Day: KadodeDiaryDailyChange;
 };
 export async function GetDailyChange(): Promise<getDailyT> {
-  const resp = await fetch(DAY_ENDPOINT, {
+  const resp = await fetch(ENDPOINT, {
     method: "GET",
   });
   if (!resp.ok) {

--- a/frontend/libs/Osirase/GetLatestOsirases.ts
+++ b/frontend/libs/Osirase/GetLatestOsirases.ts
@@ -1,7 +1,8 @@
 import {tPArticleT} from "@🧩/article.ts";
-const ENDPOINT = "https://note.com/api/v2/creators/kadoday/contents?kind=note&page=1";
-
-export async function GetArticlesByKadodeNote(): Promise<tPArticleT[]> {
+const ENDPOINT = Deno.env.get("API_URL") +
+  "/Osirase/latest";
+  
+export async function GetLatestOsirases(): Promise<tPArticleT[]> {
   const resp = await fetch(ENDPOINT, {
     method: "GET",
   });
@@ -14,13 +15,13 @@ export async function GetArticlesByKadodeNote(): Promise<tPArticleT[]> {
     throw new Error(jsonData.errors.map((e: Error) => e.message).join("\n"));
   }
   /** タイトルとURLを取り出す */
-  return jsonData.data.contents.map((e: any) => {
+  return jsonData.map((e: any) => {
+    const date=e.created_at;
         return {
-            title: e.name,
-            url: e.noteUrl,
-            date: new Date(e.publishAt),
+            title: e.title,
+            url: e.url,
+            date: new Date(e.date.replace("Z", "+09:00")),
             // body:e.body,
-            // thumbnailUrl:e.eyecatch,
             
         };
     });

--- a/frontend/libs/ReleaseNote/GetLatestReleaseNotes.ts
+++ b/frontend/libs/ReleaseNote/GetLatestReleaseNotes.ts
@@ -1,7 +1,8 @@
 import {tPArticleT} from "@🧩/article.ts";
-const ENDPOINT = "https://note.com/api/v2/creators/kadoday/contents?kind=note&page=1";
-
-export async function GetArticlesByKadodeNote(): Promise<tPArticleT[]> {
+const ENDPOINT = Deno.env.get("API_URL") +
+  "/ReleaseNote/latest";
+  
+export async function GetLatestReleaseNotes(): Promise<tPArticleT[]> {
   const resp = await fetch(ENDPOINT, {
     method: "GET",
   });
@@ -14,13 +15,12 @@ export async function GetArticlesByKadodeNote(): Promise<tPArticleT[]> {
     throw new Error(jsonData.errors.map((e: Error) => e.message).join("\n"));
   }
   /** タイトルとURLを取り出す */
-  return jsonData.data.contents.map((e: any) => {
+  return jsonData.map((e: any) => {
         return {
-            title: e.name,
-            url: e.noteUrl,
-            date: new Date(e.publishAt),
+            title: e.title,
+            url: e.url,
+            date: new Date(e.date.replace("Z", "+09:00")),
             // body:e.body,
-            // thumbnailUrl:e.eyecatch,
             
         };
     });

--- a/frontend/routes/index.tsx
+++ b/frontend/routes/index.tsx
@@ -7,6 +7,8 @@ import {
   getDailyT,
 } from "@💿/OperationCoreTransition/GetDailyChange.ts";
 import { GetArticlesByKadodeNote } from "@💿/Note/GetArticlesByKadodeNote.ts";
+import { GetLatestOsirases } from "@💿/Osirase/GetLatestOsirases.ts";
+import { GetLatestReleaseNotes } from "@💿/ReleaseNote/GetLatestReleaseNotes.ts";
 import { CreateOperationCoreChartDataToD3nodata } from "@💿/OperationCoreTransition/CreateOperationCoreChartDataToD3nodata.ts";
 //型
 import { lineChartT } from "@🧩/d3nodata.ts";
@@ -19,7 +21,8 @@ import ProductIntroCard from "@🗃/Card/ProductIntroCard.tsx";
 import ExternalServiceIntroCard from "@🗃/Card/ExternalServiceIntroCard.tsx";
 //フレーム
 import IndexArticleFrame from "@🗃/Frame/IndexArticleFrame.tsx";
-
+//文字
+import IndexHeadline from "@🗃/Text/IndexHeadline.tsx";
 //グラフ
 import D3nodataLineChart from "@🏝/D3nodataLineChart.tsx";
 
@@ -27,6 +30,8 @@ type forIndexData = {
   daily: getDailyT;
   monthlyChart: lineChartT[];
   noteArticles: tPArticleT[];
+  latestOsirases: tPArticleT[];
+  latestReleaseNotes: tPArticleT[];
 };
 
 export const handler: Handlers<forIndexData> = {
@@ -35,10 +40,14 @@ export const handler: Handlers<forIndexData> = {
     const diaryStatisticMonthlyData =
       await CreateOperationCoreChartDataToD3nodata<lineChartT[]>();
     const noteArticles = await GetArticlesByKadodeNote<tPArticleT[]>();
+    const latestOsirases = await GetLatestOsirases<tPArticleT[]>();
+    const latestReleaseNotes = await GetLatestReleaseNotes<tPArticleT[]>();
     return ctx.render({
       daily: dailyData,
       diaryStatisticMonthlyData: diaryStatisticMonthlyData,
       noteArticles: noteArticles,
+      latestOsirases: latestOsirases,
+      latestReleaseNotes: latestReleaseNotes,
     });
   },
 };
@@ -48,7 +57,7 @@ export default function Home({ data }: PageProps<forIndexData>) {
   const last1Day = data.daily.last1Day;
   return (
     <Layout title="top">
-      <div class="p-4 mx-auto max-w-screen-md">
+      <div class="p-4 mx-auto">
         <h1 class="bg-kn_white text-3xl text-center ">かどでプロジェクト</h1>
         <KadodeLogoAnimation />
         <p class="bg-kn_white text-center text-2xl my-2">
@@ -78,11 +87,22 @@ export default function Home({ data }: PageProps<forIndexData>) {
             />
           </div>
         </div>
+        <IndexHeadline title="📈利用状況の推移" />
         <div class="graphSection">
-          <h2 class="m-4 text-3xl text-center mt-12">📈利用状況の推移</h2>
           <D3nodataLineChart chartData={data.diaryStatisticMonthlyData} />
         </div>
-        <h2 class="m-4 text-3xl text-center mb-8">🍸こんなことやってます！</h2>
+        <IndexHeadline title="🦅情報" />
+        <div class="flex justify-center flex-wrap">
+          <div class="md:w-1/2">
+            <h3 class="text-2xl text-center mt-4">お知らせ</h3>
+            <IndexArticleFrame articlesData={data.latestOsirases} />
+          </div>
+          <div class="md:w-1/2">
+            <h3 class="text-2xl text-center mt-4">リリースノート</h3>
+            <IndexArticleFrame articlesData={data.latestReleaseNotes} />
+          </div>
+        </div>
+        <IndexHeadline title="🍸こんなことやってます！" />
         <ProductIntroCard
           title="かどで日記"
           url="https://kado.day"
@@ -111,7 +131,9 @@ export default function Home({ data }: PageProps<forIndexData>) {
           description="かどで日記の情報を電子ペーパーで表示する！"
           img_url="img/productImage/paper/paper1.jpg"
         /> */}
-        <h2 class="m-4 text-3xl text-center mb-8 mt-24">🍹よければこちらも</h2>
+        <IndexHeadline title="🍹よければこちらも" />
+        <h3 class="text-2xl text-center mt-4">note最新記事</h3>
+        <IndexArticleFrame articlesData={data.noteArticles} />
         <div class="flex justify-center flex-wrap">
           <ExternalServiceIntroCard
             title="かどでプロジェクト公式note"
@@ -123,13 +145,6 @@ export default function Home({ data }: PageProps<forIndexData>) {
             url="https://github.com/KadodeProject"
             imgUrl="img/logo/github/GitHub-Mark-120px-plus.png"
           />
-        </div>
-      </div>
-      <h2 class="m-4 text-3xl text-center mb-8 mt-24">🦅情報</h2>
-      <div class="flex justify-center flex-wrap">
-        <div class="md:w-1/2">
-          <h3 class="text-2xl text-center mt-4">noteより</h3>
-          <IndexArticleFrame articlesData={data.noteArticles} />
         </div>
       </div>
     </Layout>

--- a/frontend/static/k5portal.css
+++ b/frontend/static/k5portal.css
@@ -17,7 +17,7 @@
   --heder-height: 40px;
   --footer-height: 120px;
   --main-padding-top: 20px;
-  --main-max-width: 1300px;
+  --main-max-width: 900px;
 }
 @font-face {
   font-display: swap;
@@ -44,7 +44,7 @@ body {
   content: "第" counter(number) "条 ";
 }
 main {
-  max-width: 38rem;
+  max-width: var(--main-max-width);
   padding: 1rem;
   margin: auto;
 }
@@ -104,4 +104,14 @@ main {
     /* 一応見れなくもないレベルまでは治したけど、中途半端にデザイン崩すので見せないほうがマシという判断 */
     display: none;
   }
+}
+
+/* グラフのコンテナを上書き */
+.chart-container {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }


### PR DESCRIPTION
# 🌟 概要
タイトルの通り
<img width="659" alt="image" src="https://user-images.githubusercontent.com/63891531/201507611-f2e959f5-eb0e-4b86-87b4-11ae69c151a0.png">

他タイトルなどを見やすくしたり軽微な変更も含む